### PR TITLE
增加两个非法用户使用Hinet进行电信诈骗的平台

### DIFF
--- a/blockList
+++ b/blockList
@@ -96,3 +96,5 @@ yunshanfu.cn
 unionpay.com
 tmall.com
 vip.com
+beanfun.com
+gashpoint.com


### PR DESCRIPTION
近日Hinet清退部分非法用途用户，封禁此类网站以备后患。